### PR TITLE
Use full paths to plugin template files

### DIFF
--- a/src/class/obf.php
+++ b/src/class/obf.php
@@ -61,7 +61,7 @@ class PluginInteractionObf extends ObfBase {
 
     public static function navigation_hook($user, &$items) {
         // Add our page link to institution admin.
-        if ($user->is_institutional_admin()) {
+        if ($user->get('admin') || $user->is_institutional_admin()) {
             $items['manageinstitutions/obf'] = array(
                 'path' => 'manageinstitutions/obf',
                 'url' => 'interaction/obf/institution.php',

--- a/src/theme/raw/badge.tpl
+++ b/src/theme/raw/badge.tpl
@@ -7,8 +7,8 @@
 
 <h1>{$badge->name}</h1>
 
-{include file="badgedetails.tpl" badge=$badge}
-{include file="tabs.tpl" tabs=$subpages selected=$page page="badge.php?institution=$institution&badgeid=$badge->id"}
+{include file="interaction:obf:badgedetails.tpl" badge=$badge}
+{include file="interaction:obf:tabs.tpl" tabs=$subpages selected=$page page="badge.php?institution=$institution&badgeid=$badge->id"}
 
 <div class="subpage">
     {$content|safe}

--- a/src/theme/raw/badgelist.tpl
+++ b/src/theme/raw/badgelist.tpl
@@ -5,7 +5,7 @@
         <p>{str tag="nobadges" section="interaction.obf"}</p>
     {else}
 
-        {include file="categories.tpl" categories=$categories}
+        {include file="interaction:obf:categories.tpl" categories=$categories}
 
         <ul id="badges">
             {foreach from=$badges item=badge}

--- a/src/theme/raw/group.tpl
+++ b/src/theme/raw/group.tpl
@@ -1,5 +1,5 @@
 {include file="header.tpl"}
-{include file="tabs.tpl" tabs=$subpages selected=$page page="group.php?id=$group"}
+{include file="interaction:obf:tabs.tpl" tabs=$subpages selected=$page page="group.php?id=$group"}
 
 <div class="subpage">
     {if $content eq false}

--- a/src/theme/raw/issue.tpl
+++ b/src/theme/raw/issue.tpl
@@ -34,7 +34,7 @@
                     {$form|safe}
                 </div>
                 <div id="badge-group-history" style="display: none" data-tab-content="history">
-                    {include file="events.tpl" events=$events badge=$badge}
+                    {include file="interaction:obf:events.tpl" events=$events badge=$badge}
                 </div>
             </div>
         </div>

--- a/src/theme/raw/manage.tpl
+++ b/src/theme/raw/manage.tpl
@@ -5,7 +5,7 @@
 <p>{str tag="institutionselectordescription" section="interaction.obf"}</p>
 {$institutionselector|safe}
 
-{include file="tabs.tpl" tabs=$subpages selected=$page page="institution.php?institution=$institution"}
+{include file="interaction:obf:tabs.tpl" tabs=$subpages selected=$page page="institution.php?institution=$institution"}
 
 <div class="subpage">
     {$content|safe}


### PR DESCRIPTION
As of Mahara 1.10, plugin templates referenced from {include}
tags, need to be fully qualified with the plugin type and name.
See https://bugs.launchpad.net/mahara/+bug/1231755/comments/9
